### PR TITLE
Now you can filter reports and download cards data

### DIFF
--- a/src/pages/charts/Charts.tsx
+++ b/src/pages/charts/Charts.tsx
@@ -6,10 +6,10 @@ import CreatorsChart from "./components/CreatorsChart";
 import WeeksChart from "./components/WeeksChart";
 import PreclassifiersChart from "./components/PreclassifiersChart";
 import { useEffect, useState } from "react";
-import { useGetCardTypesCatalogsMutation } from '../../services/CardTypesService';
+import { useGetCardTypesCatalogsMutation } from "../../services/CardTypesService";
 import { CardTypesCatalog } from "../../data/cardtypes/cardTypes";
 import MethodologiesChart from "./components/MethodologiesChart";
-import { Card, Empty } from "antd";
+import { Card, DatePicker, Empty, Space, TimeRangePickerProps } from "antd";
 import { useGetMethodologiesChartDataMutation } from "../../services/chartService";
 import { Methodology } from "../../data/charts/charts";
 import { UnauthorizedRoute } from "../../utils/Routes";
@@ -17,6 +17,18 @@ import MachinesChart from "./components/MachinesChart";
 import MechanicsChart from "./components/MechanicsChart";
 import DefinitiveUsersChart from "./components/DefinitiveUsersChart";
 import { UserRoles } from "../../utils/Extensions";
+import dayjs from "dayjs";
+import type { Dayjs } from "dayjs";
+import DownloadCarDataExceButton from "./components/DownloadCardDataExcelButton";
+
+const { RangePicker } = DatePicker;
+
+const rangePresets: TimeRangePickerProps["presets"] = [
+  { label: Strings.last7days, value: [dayjs().add(-7, "d"), dayjs()] },
+  { label: Strings.last14days, value: [dayjs().add(-14, "d"), dayjs()] },
+  { label: Strings.last30days, value: [dayjs().add(-30, "d"), dayjs()] },
+  { label: Strings.last90days, value: [dayjs().add(-90, "d"), dayjs()] },
+];
 
 interface Props {
   rol: UserRoles;
@@ -31,6 +43,8 @@ const Charts = ({ rol }: Props) => {
   >([]);
   const [methodologies, setMethodologies] = useState<Methodology[]>([]);
   const navigate = useNavigate();
+  const [startDate, setStartDate] = useState(Strings.empty);
+  const [endDate, setEndDate] = useState(Strings.empty);
 
   const handleGetMethodologiesCatalog = async () => {
     if (!location.state) {
@@ -39,7 +53,11 @@ const Charts = ({ rol }: Props) => {
     }
     const [response, response2] = await Promise.all([
       getMethodologiesCatalog().unwrap(),
-      getMethodologies(location.state.siteId).unwrap(),
+      getMethodologies({
+        siteId,
+        startDate,
+        endDate,
+      }).unwrap(),
     ]);
 
     setMethodologiesCatalog(response);
@@ -50,14 +68,43 @@ const Charts = ({ rol }: Props) => {
     handleGetMethodologiesCatalog();
   }, [location.state]);
 
+  useEffect(() => {
+    handleGetMethodologiesCatalog();
+  }, [startDate, endDate]);
+
   const siteName = location?.state?.siteName || Strings.empty;
   const siteId = location?.state?.siteId || Strings.empty;
+
+  const onRangeChange = (
+    dates: null | (Dayjs | null)[],
+    dateStrings: string[]
+  ) => {
+    if (dates) {
+      setStartDate(dateStrings[0]);
+      setEndDate(dateStrings[1]);
+    } else {
+      setStartDate(Strings.empty);
+      setEndDate(Strings.empty);
+    }
+  };
 
   return (
     <>
       <div className="h-full flex flex-col">
-        <div className="flex gap-2 justify-center flex-wrap items-center m-3">
-          <PageTitle mainText={Strings.chartsOf} subText={siteName} />
+        <div className="flex flex-col gap-2 items-center m-3">
+          <div className="flex flex-wrap gap-2">
+            <PageTitle mainText={Strings.usersOf} subText={siteName} />
+            <div className=" flex items-center">
+              <DownloadCarDataExceButton siteId={siteId} />
+            </div>
+          </div>
+          <div className="flex flex-col md:flex-row flex-wrap items-center md:justify-between w-full">
+            <div className="flex flex-col md:flex-row items-center flex-1 mb-1 md:mb-0">
+              <Space className="w-full md:w-auto mb-1 md:mb-0">
+                <RangePicker presets={rangePresets} onChange={onRangeChange} />
+              </Space>
+            </div>
+          </div>
         </div>
         <div className="flex-1 overflow-auto">
           {methodologies.length > 0 ? (
@@ -91,7 +138,12 @@ const Charts = ({ rol }: Props) => {
                     </div>
                     <div className="flex flex-wrap gap-1">
                       <div className="md:flex-1 w-full h-60">
-                        <PreclassifiersChart siteId={siteId} rol={rol} />
+                        <PreclassifiersChart
+                          siteId={siteId}
+                          startDate={startDate}
+                          endDate={endDate}
+                          rol={rol}
+                        />
                       </div>
                       <div className="md:w-80 w-full h-60">
                         <MethodologiesChart
@@ -116,6 +168,8 @@ const Charts = ({ rol }: Props) => {
                 >
                   <div className="w-full h-60">
                     <AreasChart
+                      startDate={startDate}
+                      endDate={endDate}
                       methodologies={methodologies}
                       siteId={siteId}
                       rol={rol}
@@ -134,6 +188,8 @@ const Charts = ({ rol }: Props) => {
                 >
                   <div className="w-full h-60">
                     <MachinesChart
+                      startDate={startDate}
+                      endDate={endDate}
                       siteId={siteId}
                       methodologies={methodologies}
                       rol={rol}
@@ -154,6 +210,8 @@ const Charts = ({ rol }: Props) => {
                 >
                   <div className="w-full h-60">
                     <CreatorsChart
+                      startDate={startDate}
+                      endDate={endDate}
                       siteId={siteId}
                       methodologies={methodologies}
                       rol={rol}
@@ -172,6 +230,8 @@ const Charts = ({ rol }: Props) => {
                 >
                   <div className="w-full h-60">
                     <MechanicsChart
+                      startDate={startDate}
+                      endDate={endDate}
                       rol={rol}
                       siteId={siteId}
                       methodologies={methodologies}
@@ -192,6 +252,8 @@ const Charts = ({ rol }: Props) => {
                 >
                   <div className="w-full h-60">
                     <DefinitiveUsersChart
+                      startDate={startDate}
+                      endDate={endDate}
                       rol={rol}
                       siteId={siteId}
                       methodologies={methodologies}

--- a/src/pages/charts/components/AreasChart.tsx
+++ b/src/pages/charts/components/AreasChart.tsx
@@ -19,11 +19,19 @@ import CustomDrawerCardList from "../../../components/CustomDrawerCardList";
 
 export interface ChartProps {
   siteId: string;
+  startDate: string;
+  endDate: string;
   methodologies: Methodology[];
   rol: UserRoles;
 }
 
-const AreasChart = ({ siteId, methodologies, rol }: ChartProps) => {
+const AreasChart = ({
+  siteId,
+  startDate,
+  endDate,
+  methodologies,
+  rol,
+}: ChartProps) => {
   const [getAreas] = useGetAreasChartDataMutation();
   const [transformedData, setTransformedData] = useState<any[]>([]);
   const [open, setOpen] = useState<boolean>(false);
@@ -41,7 +49,11 @@ const AreasChart = ({ siteId, methodologies, rol }: ChartProps) => {
   });
 
   const handleGetData = async () => {
-    const response = await getAreas(siteId).unwrap();
+    const response = await getAreas({
+      siteId,
+      startDate,
+      endDate,
+    }).unwrap();
     const areaMap: { [key: string]: any } = {};
     response.forEach((item: any) => {
       if (!areaMap[item.area]) {
@@ -58,7 +70,7 @@ const AreasChart = ({ siteId, methodologies, rol }: ChartProps) => {
 
   useEffect(() => {
     handleGetData();
-  }, []);
+  }, [startDate, endDate]);
 
   const handleOnClick = (data: any, cardTypeName: string) => {
     setSearchParams({

--- a/src/pages/charts/components/CreatorsChart.tsx
+++ b/src/pages/charts/components/CreatorsChart.tsx
@@ -19,11 +19,19 @@ import { UserRoles } from "../../../utils/Extensions";
 
 export interface ChartProps {
   siteId: string;
+  startDate: string;
+  endDate: string;
   rol: UserRoles;
   methodologies: Methodology[];
 }
 
-const CreatorsChart = ({ siteId, methodologies, rol }: ChartProps) => {
+const CreatorsChart = ({
+  siteId,
+  startDate,
+  endDate,
+  methodologies,
+  rol,
+}: ChartProps) => {
   const [getCreators] = useGetCreatorsChartDataMutation();
   const [transformedData, setTransformedData] = useState<any[]>([]);
   const [open, setOpen] = useState<boolean>(false);
@@ -41,7 +49,11 @@ const CreatorsChart = ({ siteId, methodologies, rol }: ChartProps) => {
   });
 
   const handleGetData = async () => {
-    const response = await getCreators(siteId).unwrap();
+    const response = await getCreators({
+      siteId,
+      startDate,
+      endDate,
+    }).unwrap();
     const creatorMap: { [key: string]: any } = {};
     response.forEach((item: any) => {
       if (!creatorMap[item.creator]) {
@@ -60,7 +72,7 @@ const CreatorsChart = ({ siteId, methodologies, rol }: ChartProps) => {
 
   useEffect(() => {
     handleGetData();
-  }, []);
+  }, [startDate, endDate]);
 
   const handleOnClick = (data: any, cardTypeName: string) => {
     setSearchParams({

--- a/src/pages/charts/components/DefinitiveUsersChart.tsx
+++ b/src/pages/charts/components/DefinitiveUsersChart.tsx
@@ -19,11 +19,19 @@ import CustomDrawerCardList from "../../../components/CustomDrawerCardList";
 
 export interface ChartProps {
   siteId: string;
+  startDate: string;
+  endDate: string;
   rol: UserRoles;
   methodologies: Methodology[];
 }
 
-const DefinitiveUsersChart = ({ siteId, methodologies, rol }: ChartProps) => {
+const DefinitiveUsersChart = ({
+  siteId,
+  startDate,
+  endDate,
+  methodologies,
+  rol,
+}: ChartProps) => {
   const [getDefinitiveUsers] = useGetDefinitiveUsersChartDataMutation();
   const [transformedData, setTransformedData] = useState<any[]>([]);
   const [open, setOpen] = useState<boolean>(false);
@@ -43,7 +51,11 @@ const DefinitiveUsersChart = ({ siteId, methodologies, rol }: ChartProps) => {
   });
 
   const handleGetData = async () => {
-    const response = await getDefinitiveUsers(siteId).unwrap();
+    const response = await getDefinitiveUsers({
+      siteId,
+      startDate,
+      endDate,
+    }).unwrap();
     const definitiveUserMap: { [key: string]: any } = {};
     response.forEach((item: any) => {
       if (!definitiveUserMap[item.definitiveUser]) {
@@ -60,7 +72,7 @@ const DefinitiveUsersChart = ({ siteId, methodologies, rol }: ChartProps) => {
 
   useEffect(() => {
     handleGetData();
-  }, []);
+  }, [startDate, endDate]);
 
   const handleOnClick = (data: any, cardTypeName: string) => {
     setSearchParams({

--- a/src/pages/charts/components/DownloadCardDataExcelButton.tsx
+++ b/src/pages/charts/components/DownloadCardDataExcelButton.tsx
@@ -1,0 +1,48 @@
+import { useState } from "react";
+import { useLazyDownloadReportQuery } from "../../../services/exportService";
+import { handleErrorNotification } from "../../../utils/Notifications";
+import CustomButton from "../../../components/CustomButtons";
+import { MdOutlineFileDownload } from "react-icons/md";
+import Strings from "../../../utils/localizations/Strings";
+
+interface Props {
+  siteId: string;
+}
+
+const DownloadCarDataExceButton = ({ siteId }: Props) => {
+  const [downloadReport, { isFetching }] = useLazyDownloadReportQuery();
+  const [loading, setLoading] = useState(false);
+
+  const handleDownload = async () => {
+    setLoading(true);
+    try {
+      const { data } = await downloadReport(siteId);
+      if (data) {
+        const url = window.URL.createObjectURL(new Blob([data]));
+        const link = document.createElement("a");
+        link.href = url;
+        link.setAttribute("download", "Tablero.xlsx");
+        document.body.appendChild(link);
+        link.click();
+        link.parentNode?.removeChild(link);
+      }
+    } catch (error) {
+      handleErrorNotification(error, Strings.failedToDownload);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <CustomButton
+      type="action"
+      onClick={handleDownload}
+      loading={loading || isFetching}
+    >
+      <MdOutlineFileDownload />
+      {Strings.downloadData}
+    </CustomButton>
+  );
+};
+
+export default DownloadCarDataExceButton;

--- a/src/pages/charts/components/MachinesChart.tsx
+++ b/src/pages/charts/components/MachinesChart.tsx
@@ -19,11 +19,19 @@ import { UserRoles } from "../../../utils/Extensions";
 
 export interface ChartProps {
   siteId: string;
+  startDate: string;
+  endDate: string;
   rol: UserRoles;
   methodologies: Methodology[];
 }
 
-const MachinesChart = ({ siteId, methodologies, rol }: ChartProps) => {
+const MachinesChart = ({
+  siteId,
+  startDate,
+  endDate,
+  methodologies,
+  rol,
+}: ChartProps) => {
   const [getMachines] = useGetMachinesChartDataMutation();
   const [transformedData, setTransformedData] = useState<any[]>([]);
   const [open, setOpen] = useState<boolean>(false);
@@ -42,7 +50,11 @@ const MachinesChart = ({ siteId, methodologies, rol }: ChartProps) => {
   });
 
   const handleGetData = async () => {
-    const response = await getMachines(siteId).unwrap();
+    const response = await getMachines({
+      siteId,
+      startDate,
+      endDate,
+    }).unwrap();
     const nodeMap: { [key: string]: any } = {};
     response.forEach((item: any) => {
       if (!nodeMap[item.nodeName]) {
@@ -62,7 +74,7 @@ const MachinesChart = ({ siteId, methodologies, rol }: ChartProps) => {
 
   useEffect(() => {
     handleGetData();
-  }, []);
+  }, [startDate, endDate]);
 
   const handleOnClick = (data: any, cardTypeName: string) => {
     setSearchParams({

--- a/src/pages/charts/components/MechanicsChart.tsx
+++ b/src/pages/charts/components/MechanicsChart.tsx
@@ -19,11 +19,19 @@ import { UserRoles } from "../../../utils/Extensions";
 
 export interface ChartProps {
   siteId: string;
+  startDate: string;
+  endDate: string;
   rol: UserRoles;
   methodologies: Methodology[];
 }
 
-const MechanicsChart = ({ siteId, methodologies, rol }: ChartProps) => {
+const MechanicsChart = ({
+  siteId,
+  startDate,
+  endDate,
+  methodologies,
+  rol,
+}: ChartProps) => {
   const [getMechanics] = useGetMechanicsChartDataMutation();
   const [transformedData, setTransformedData] = useState<any[]>([]);
   const [open, setOpen] = useState<boolean>(false);
@@ -43,7 +51,11 @@ const MechanicsChart = ({ siteId, methodologies, rol }: ChartProps) => {
   });
 
   const handleGetData = async () => {
-    const response = await getMechanics(siteId).unwrap();
+    const response = await getMechanics({
+      siteId,
+      startDate,
+      endDate,
+    }).unwrap();
     const mechanicMap: { [key: string]: any } = {};
     response.forEach((item: any) => {
       if (!mechanicMap[item.mechanic]) {
@@ -62,7 +74,7 @@ const MechanicsChart = ({ siteId, methodologies, rol }: ChartProps) => {
 
   useEffect(() => {
     handleGetData();
-  }, []);
+  }, [startDate, endDate]);
 
   const handleOnClick = (data: any, cardTypeName: string) => {
     setSearchParams({

--- a/src/pages/charts/components/PreclassifiersChart.tsx
+++ b/src/pages/charts/components/PreclassifiersChart.tsx
@@ -18,10 +18,17 @@ import { UserRoles } from "../../../utils/Extensions";
 
 export interface ChartProps {
   siteId: string;
+  startDate: string;
+  endDate: string;
   rol: UserRoles;
 }
 
-const PreclassifiersChart = ({ siteId, rol }: ChartProps) => {
+const PreclassifiersChart = ({
+  siteId,
+  startDate,
+  endDate,
+  rol,
+}: ChartProps) => {
   const [getAnomalies] = useGetPreclassifiersChartDataMutation();
   const [preclassifiers, setPreclassifiers] = useState<Preclassifier[]>([]);
   const [open, setOpen] = useState<boolean>(false);
@@ -53,13 +60,17 @@ const PreclassifiersChart = ({ siteId, rol }: ChartProps) => {
   };
 
   const handleGetData = async () => {
-    const response = await getAnomalies(siteId).unwrap();
+    const response = await getAnomalies({
+      siteId,
+      startDate,
+      endDate,
+    }).unwrap();
     setPreclassifiers(response);
   };
 
   useEffect(() => {
     handleGetData();
-  }, []);
+  }, [startDate, endDate]);
 
   return (
     <>

--- a/src/services/chartService.ts
+++ b/src/services/chartService.ts
@@ -11,32 +11,109 @@ import { apiSlice } from "./apiSlice";
 
 export const chartService = apiSlice.injectEndpoints({
   endpoints: (builder) => ({
-    getPreclassifiersChartData: builder.mutation<Preclassifier[], string>({
-      query: (siteId) => `/card/site/preclassifiers/${siteId}`,
+    getPreclassifiersChartData: builder.mutation<
+      Preclassifier[],
+      { siteId: string; startDate?: string; endDate?: string }
+    >({
+      query: ({ siteId, startDate, endDate }) => {
+        let url = `/card/site/preclassifiers/${siteId}`;
+        if (startDate || endDate) {
+          url += `?${startDate ? `startDate=${startDate}&` : ""}${
+            endDate ? `endDate=${endDate}` : ""
+          }`;
+        }
+        return url;
+      },
       transformResponse: (response: { data: Preclassifier[] }) => response.data,
     }),
-    getMethodologiesChartData: builder.mutation<Preclassifier[], string>({
-      query: (siteId) => `/card/site/methodologies/${siteId}`,
+    getMethodologiesChartData: builder.mutation<
+      Preclassifier[],
+      { siteId: string; startDate?: string; endDate?: string }
+    >({
+      query: ({ siteId, startDate, endDate }) => {
+        let url = `/card/site/methodologies/${siteId}`;
+        if (startDate || endDate) {
+          url += `?${startDate ? `startDate=${startDate}&` : ""}${
+            endDate ? `endDate=${endDate}` : ""
+          }`;
+        }
+        return url;
+      },
       transformResponse: (response: { data: Preclassifier[] }) => response.data,
     }),
-    getAreasChartData: builder.mutation<Area[], string>({
-      query: (siteId) => `/card/site/areas/${siteId}`,
+    getAreasChartData: builder.mutation<
+      Area[],
+      { siteId: string; startDate?: string; endDate?: string }
+    >({
+      query: ({ siteId, startDate, endDate }) => {
+        let url = `/card/site/areas/${siteId}`;
+        if (startDate || endDate) {
+          url += `?${startDate ? `startDate=${startDate}&` : ""}${
+            endDate ? `endDate=${endDate}` : ""
+          }`;
+        }
+        return url;
+      },
       transformResponse: (response: { data: Area[] }) => response.data,
     }),
-    getMachinesChartData: builder.mutation<Machine[], string>({
-      query: (siteId) => `/card/site/machines/${siteId}`,
+    getMachinesChartData: builder.mutation<
+      Machine[],
+      { siteId: string; startDate?: string; endDate?: string }
+    >({
+      query: ({ siteId, startDate, endDate }) => {
+        let url = `/card/site/machines/${siteId}`;
+        if (startDate || endDate) {
+          url += `?${startDate ? `startDate=${startDate}&` : ""}${
+            endDate ? `endDate=${endDate}` : ""
+          }`;
+        }
+        return url;
+      },
       transformResponse: (response: { data: Machine[] }) => response.data,
     }),
-    getCreatorsChartData: builder.mutation<Creator[], string>({
-      query: (siteId) => `/card/site/creators/${siteId}`,
+    getCreatorsChartData: builder.mutation<
+      Creator[],
+      { siteId: string; startDate?: string; endDate?: string }
+    >({
+      query: ({ siteId, startDate, endDate }) => {
+        let url = `/card/site/creators/${siteId}`;
+        if (startDate || endDate) {
+          url += `?${startDate ? `startDate=${startDate}&` : ""}${
+            endDate ? `endDate=${endDate}` : ""
+          }`;
+        }
+        return url;
+      },
       transformResponse: (response: { data: Creator[] }) => response.data,
     }),
-    getMechanicsChartData: builder.mutation<Mechanic[], string>({
-      query: (siteId) => `/card/site/mechanics/${siteId}`,
+    getMechanicsChartData: builder.mutation<
+      Mechanic[],
+      { siteId: string; startDate?: string; endDate?: string }
+    >({
+      query: ({ siteId, startDate, endDate }) => {
+        let url = `/card/site/mechanics/${siteId}`;
+        if (startDate || endDate) {
+          url += `?${startDate ? `startDate=${startDate}&` : ""}${
+            endDate ? `endDate=${endDate}` : ""
+          }`;
+        }
+        return url;
+      },
       transformResponse: (response: { data: Mechanic[] }) => response.data,
     }),
-    getDefinitiveUsersChartData: builder.mutation<DefinitiveUser[], string>({
-      query: (siteId) => `/card/site/definitive-user/${siteId}`,
+    getDefinitiveUsersChartData: builder.mutation<
+      DefinitiveUser[],
+      { siteId: string; startDate?: string; endDate?: string }
+    >({
+      query: ({ siteId, startDate, endDate }) => {
+        let url = `/card/site/definitive-user/${siteId}`;
+        if (startDate || endDate) {
+          url += `?${startDate ? `startDate=${startDate}&` : ""}${
+            endDate ? `endDate=${endDate}` : ""
+          }`;
+        }
+        return url;
+      },
       transformResponse: (response: { data: DefinitiveUser[] }) =>
         response.data,
     }),
@@ -55,5 +132,5 @@ export const {
   useGetMethodologiesChartDataMutation,
   useGetMachinesChartDataMutation,
   useGetMechanicsChartDataMutation,
-  useGetDefinitiveUsersChartDataMutation
+  useGetDefinitiveUsersChartDataMutation,
 } = chartService;

--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -1,0 +1,15 @@
+import { apiSlice } from "./apiSlice";
+
+export const exportService = apiSlice.injectEndpoints({
+  endpoints: (builder) => ({
+    downloadReport: builder.query({
+      query: (siteId) => ({
+        url: `export/card-data/site/${siteId}`,
+        method: "GET",
+        responseHandler: (response) => response.blob(),
+      }),
+    }),
+  }),
+});
+
+export const { useLazyDownloadReportQuery } = exportService;

--- a/src/utils/localizations/Strings.ts
+++ b/src/utils/localizations/Strings.ts
@@ -114,6 +114,7 @@ export default class Strings {
   static viewCharts = "View charts";
   static viewUsers = "View users";
   static importUsers = "Import users";
+  static downloadData = "Download data";
 
   //erros sites form
   static requiredLatitud = "Please enter the latitud";
@@ -304,6 +305,14 @@ export default class Strings {
   static cardParam = ":card";
   static cardTypeParam = ":cardType";
   static colon = ":";
+
+  //Rangepricker presets
+  static last7days = "Last 7 Days";
+  static last14days = "Last 14 Days";
+  static last30days = "Last 30 Days";
+  static last90days = "Last 90 Days";
+
+  static failedToDownload = "Failed to download";
 
   //warning notifications
   static restrictedAccessMessage =


### PR DESCRIPTION
### Feature / Bug Description
Now you can filter reports and download cards data

### Solution
A button to achieve the download of card data was added in charts.tsx
Was added a filter with a range picker to get the reports by a range date in charts.tsx

### Notes
no notes needed

### Tickets
[[TICKET](https://cdentalcaregroup.atlassian.net/browse/)](https://cdentalcaregroup.atlassian.net/browse/WMA-171)

### Screenshots / Screencasts
![image](https://github.com/user-attachments/assets/dbee01fc-e1bd-442f-bce2-6c54ea23fb74)
